### PR TITLE
Test with hypothesis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 platform=$(shell uname -s)
 conda_path=$(shell which conda)
 
-.PHONY: show check-env venv check run
+.PHONY: show check-env venv check run hyp
 
 
 ifeq ($(platform),Darwin)
@@ -52,6 +52,9 @@ clean:
 check: | $(VENVDIR)
 	$(PYVENV) ./test_summarizer.py;\
 	$(PYVENV) ./test_service_components.py
+
+hyp: | $(VENVDIR)
+	$(PYVENV) ./test_hypothesis_summarizer.py
 
 run: | $(VENVDIR)
 	$(PYVENV) ./ts_summarizer.py

--- a/interval_summarizer.py
+++ b/interval_summarizer.py
@@ -125,7 +125,7 @@ def tagged_sum(msg):
         user = msg['user']
     elif 'bot_id' in msg:
         user = u'BOT'+msg['bot_id']
-    return u'@{}  <{}>: {}'.format(ts_to_time(msg['ts']).strftime("%H:%M:%S %Z"), user,  get_msg_text(msg))
+    return u'@{}  <{}>: {}'.format(ts_to_time(msg['ts']).strftime("%a-%b-%-m-%Y %H:%M:%S %Z"), user,  get_msg_text(msg))
 
 def ts_to_time(slack_ts):
     """

--- a/interval_summarizer.py
+++ b/interval_summarizer.py
@@ -139,5 +139,6 @@ def ts_to_time(slack_ts):
 def canonicalize(txt):
     """Filter and change text to sentece form"""
     ntxt = TsSummarizer.flrg.sub(u'', txt)
-    return u'{} '.format(ntxt) if re.match(r'.*[\.\?]$', ntxt) else u'{}. '.format(ntxt)
+    return ntxt.strip() if re.match(r'.*[\.\?\!]\s*$', ntxt) else u'{}.'.format(ntxt.strip())
+    #return ntxt if re.match(r'.*[\.\?]$', ntxt) else u'{}.'.format(ntxt)
 

--- a/interval_summarizer.py
+++ b/interval_summarizer.py
@@ -8,6 +8,7 @@ import json
 import io
 from ts_config import TS_DEBUG, TS_LOG
 import glob
+from utils import get_msg_text
 logging.basicConfig(level=logging.INFO)
 
 class IntervalSpec(object):
@@ -73,13 +74,16 @@ class TsSummarizer(object):
         idx_start = 0
         idx_end = 0
         interval_start = None
-        msgs = [msg for msg in messages if u'attachments' not in msg and u'text' in msg and u'subtype' not in msg]
+        msgs = [msg for msg in messages if u'attachments' in msg or u'text' in msg ]
         if len(msgs) == 0:
-            msgs = [msg for msg in messages if u'text' in msg and u'subtype' not in msg]
-            if len(msgs) == 0:
-                msgs = [msg for msg in messages if u'text' in msg]
-                if len(msgs) == 0:
-                    return [(self.intervals[0].size, msgs, self.intervals[0].txt)]
+            return [(self.intervals[0].size, None, self.intervals[0].txt)]
+        # msgs = [msg for msg in messages if u'attachments' not in msg and u'text' in msg and u'subtype' not in msg]
+        # if len(msgs) == 0:
+        #     msgs = [msg for msg in messages if u'text' in msg and u'subtype' not in msg]
+        #     if len(msgs) == 0:
+        #         msgs = [msg for msg in messages if u'text' in msg]
+        #         if len(msgs) == 0:
+        #             return [(self.intervals[0].size, msgs, self.intervals[0].txt)]
         if len(msgs) == 1:
             return [(self.intervals[0].size, msgs, self.intervals[0].txt)]
         smessages = sorted(msgs, reverse=True, key=lambda msg: ts_to_time(msg['ts']))
@@ -121,7 +125,7 @@ def tagged_sum(msg):
         user = msg['user']
     elif 'bot_id' in msg:
         user = u'BOT'+msg['bot_id']
-    return u'@{}  <{}>: {}'.format(ts_to_time(msg['ts']).strftime("%H:%M:%S %Z"), user,  msg['text'])
+    return u'@{}  <{}>: {}'.format(ts_to_time(msg['ts']).strftime("%H:%M:%S %Z"), user,  get_msg_text(msg))
 
 def ts_to_time(slack_ts):
     """

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,3 +15,4 @@ jupyter
 mock==1.3.0
 pbr==1.8.1
 spacy==0.94
+hypothesis

--- a/test_hypothesis_summarizer.py
+++ b/test_hypothesis_summarizer.py
@@ -20,8 +20,10 @@ logger.level = logging.DEBUG if DEBUG else logging.INFO
 test_json_msgs = json.load(io.open("./test-events.json", encoding='utf-8'))['messages']
 test_json_msgs_c2 = json.load(io.open("./data/test-events-elastic.json", encoding='utf-8'))['messages']
 test_json_msgs_c3 = []
-for jfile in glob.glob('./data/slack-logs-2/jetpack/*.json'):
-    test_json_msgs_c3 += json.load(io.open(jfile, encoding='utf-8'))
+
+for dirs in ['api-test',  'calypso',  'games',  'happiness',  'hg',  'jetpack',  'jetpackfuel',  'livechat',  'tickets',  'vip']:
+    for jfile in glob.glob('./data/slack-logs-2/{}/*.json'.format(dirs)):
+        test_json_msgs_c3 += json.load(io.open(jfile, encoding='utf-8'))
 
 print len(test_json_msgs_c3)
 

--- a/test_hypothesis_summarizer.py
+++ b/test_hypothesis_summarizer.py
@@ -13,11 +13,17 @@ from ts_config import DEBUG
 from hypothesis import given
 #import hypothesis.strategies as st
 from hypothesis.strategies import (sampled_from, lists, just, integers)
+import glob
 
 logger = logging.getLogger()
 logger.level = logging.DEBUG if DEBUG else logging.INFO
 test_json_msgs = json.load(io.open("./test-events.json", encoding='utf-8'))['messages']
 test_json_msgs_c2 = json.load(io.open("./data/test-events-elastic.json", encoding='utf-8'))['messages']
+test_json_msgs_c3 = []
+for jfile in glob.glob('./data/slack-logs-2/jetpack/*.json'):
+    test_json_msgs_c3 += json.load(io.open(jfile, encoding='utf-8'))
+
+print len(test_json_msgs_c3)
 
 class TestSummarize(unittest.TestCase):
 
@@ -61,6 +67,25 @@ class TestSummarize(unittest.TestCase):
         # Each message in the summary must correspond to a message
 
 
+    @given(
+        lists(elements=sampled_from(test_json_msgs_c3), min_size=1),
+        integers(min_value=1, max_value=20)
+    )
+    def test_text_rank_summarization_ds3_days(self, smp_msgs, days):
+        """Generate something for N day interval"""
+        logger.info("Input is %s", smp_msgs)
+        asd = [{'days': days, 'size' : 3, 'txt' : u'Summary for first {} days:\n'.format(days)}]
+        summ = TextRankTsSummarizer(asd)
+        sumry = summ.summarize(smp_msgs)
+        logger.debug("Summary is %s", sumry)
+        # Length of summary is at least 1 and no greater than 3
+        self.assertTrue(len(sumry) >= 1)
+        self.assertTrue(len(sumry) <= 3)
+        # Length of summary is less than or equal to the original length
+        self.assertTrue(len(sumry) <= len(smp_msgs))
+        # Each message in the summary must correspond to a message
+
+
     @given(lists(elements=sampled_from(test_json_msgs), min_size=1),
            integers(min_value=1, max_value=24)
     )
@@ -83,6 +108,24 @@ class TestSummarize(unittest.TestCase):
            integers(min_value=1, max_value=24)
     )
     def test_text_rank_summarization_ds2_hours(self, smp_msgs, hours):
+        """Generate something for N hour intervals"""
+        logger.info("Input is %s", smp_msgs)
+        asd = [{'hours': hours, 'size' : 3, 'txt' : u'Summary for first {} minutes:\n'.format(hours)}]
+        summ = TextRankTsSummarizer(asd)
+        sumry = summ.summarize(smp_msgs)
+        logger.debug("Summary is %s", sumry)
+        # Length of summary is at least 1 and no greater than 3
+        self.assertTrue(len(sumry) >= 1)
+        self.assertTrue(len(sumry) <= 3)
+        # Length of summary is less than or equal to the original length
+        self.assertTrue(len(sumry) <= len(smp_msgs))
+        # Each message in the summary must correspond to a message
+        
+
+    @given(lists(elements=sampled_from(test_json_msgs_c3), min_size=1),
+           integers(min_value=1, max_value=24)
+    )
+    def test_text_rank_summarization_ds3_hours(self, smp_msgs, hours):
         """Generate something for N hour intervals"""
         logger.info("Input is %s", smp_msgs)
         asd = [{'hours': hours, 'size' : 3, 'txt' : u'Summary for first {} minutes:\n'.format(hours)}]

--- a/test_hypothesis_summarizer.py
+++ b/test_hypothesis_summarizer.py
@@ -1,0 +1,102 @@
+import unittest
+import json
+import io
+#from sp_summarizer import (SpacyTsSummarizer)
+from ts_summarizer import (TextRankTsSummarizer)
+from interval_summarizer import (IntervalSpec, TsSummarizer, tagged_sum,
+                                 ts_to_time)
+from datetime import datetime
+import logging
+import sys
+import config
+from ts_config import DEBUG
+from hypothesis import given
+#import hypothesis.strategies as st
+from hypothesis.strategies import (sampled_from, lists, just, integers)
+
+logger = logging.getLogger()
+logger.level = logging.DEBUG if DEBUG else logging.INFO
+test_json_msgs = json.load(io.open("./test-events.json", encoding='utf-8'))['messages']
+test_json_msgs_c2 = json.load(io.open("./data/test-events-elastic.json", encoding='utf-8'))['messages']
+
+class TestSummarize(unittest.TestCase):
+
+    test_msgs = test_json_msgs
+
+    @given(
+        lists(elements=sampled_from(test_json_msgs), min_size=1),
+        integers(min_value=1, max_value=20)
+    )
+    def test_text_rank_summarization_ds1_days(self, smp_msgs, days):
+        """Generate something for N day interval"""
+        logger.info("Input is %s", smp_msgs)
+        asd = [{'days': days, 'size' : 3, 'txt' : u'Summary for first {} days:\n'.format(days)}]
+        summ = TextRankTsSummarizer(asd)
+        sumry = summ.summarize(smp_msgs)
+        logger.debug("Summary is %s", sumry)
+        # Length of summary is at least 1 and no greater than 3
+        self.assertTrue(len(sumry) >= 1)
+        self.assertTrue(len(sumry) <= 3)
+        # Length of summary is less than or equal to the original length
+        self.assertTrue(len(sumry) <= len(smp_msgs))
+        # Each message in the summary must correspond to a message
+
+
+    @given(
+        lists(elements=sampled_from(test_json_msgs_c2), min_size=1),
+        integers(min_value=1, max_value=20)
+    )
+    def test_text_rank_summarization_ds2_days(self, smp_msgs, days):
+        """Generate something for N day interval"""
+        logger.info("Input is %s", smp_msgs)
+        asd = [{'days': days, 'size' : 3, 'txt' : u'Summary for first {} days:\n'.format(days)}]
+        summ = TextRankTsSummarizer(asd)
+        sumry = summ.summarize(smp_msgs)
+        logger.debug("Summary is %s", sumry)
+        # Length of summary is at least 1 and no greater than 3
+        self.assertTrue(len(sumry) >= 1)
+        self.assertTrue(len(sumry) <= 3)
+        # Length of summary is less than or equal to the original length
+        self.assertTrue(len(sumry) <= len(smp_msgs))
+        # Each message in the summary must correspond to a message
+
+
+    @given(lists(elements=sampled_from(test_json_msgs), min_size=1),
+           integers(min_value=1, max_value=24)
+    )
+    def test_text_rank_summarization_ds1_hours(self, smp_msgs, hours):
+        """Generate something for N hour intervals"""
+        logger.info("Input is %s", smp_msgs)
+        asd = [{'hours': hours, 'size' : 3, 'txt' : u'Summary for first {} minutes:\n'.format(hours)}]
+        summ = TextRankTsSummarizer(asd)
+        sumry = summ.summarize(smp_msgs)
+        logger.debug("Summary is %s", sumry)
+        # Length of summary is at least 1 and no greater than 3
+        self.assertTrue(len(sumry) >= 1)
+        self.assertTrue(len(sumry) <= 3)
+        # Length of summary is less than or equal to the original length
+        self.assertTrue(len(sumry) <= len(smp_msgs))
+        # Each message in the summary must correspond to a message
+        
+
+    @given(lists(elements=sampled_from(test_json_msgs_c2), min_size=1),
+           integers(min_value=1, max_value=24)
+    )
+    def test_text_rank_summarization_ds2_hours(self, smp_msgs, hours):
+        """Generate something for N hour intervals"""
+        logger.info("Input is %s", smp_msgs)
+        asd = [{'hours': hours, 'size' : 3, 'txt' : u'Summary for first {} minutes:\n'.format(hours)}]
+        summ = TextRankTsSummarizer(asd)
+        sumry = summ.summarize(smp_msgs)
+        logger.debug("Summary is %s", sumry)
+        # Length of summary is at least 1 and no greater than 3
+        self.assertTrue(len(sumry) >= 1)
+        self.assertTrue(len(sumry) <= 3)
+        # Length of summary is less than or equal to the original length
+        self.assertTrue(len(sumry) <= len(smp_msgs))
+        # Each message in the summary must correspond to a message
+        
+
+if __name__ == '__main__':
+    unittest.main()
+

--- a/ts_summarizer.py
+++ b/ts_summarizer.py
@@ -16,6 +16,7 @@ from ts_config import TS_DEBUG, TS_LOG
 import glob
 from interval_summarizer import (IntervalSpec, TsSummarizer,
                                  canonicalize, ts_to_time, tagged_sum)
+from utils import get_msg_text
 logging.basicConfig(level=logging.INFO)
 
 class TextRankTsSummarizer(TsSummarizer):
@@ -41,12 +42,12 @@ class TextRankTsSummarizer(TsSummarizer):
            until this can be fixed
         """
         size, msgs, txt = msg_segment
-        if len(msgs) == 0:
+        if not msgs or len(msgs) == 0:
             self.logger.warn("No messages to form summary")
             return u"\n Unable to form summary here.\n"
         ratio = size / float(len(msgs))
         summ = txt + u' '
-        can_dict = {canonicalize(msg['text']) : msg for msg in msgs if 'text' in msg}
+        can_dict = {canonicalize(get_msg_text(msg)) : msg for msg in msgs}
         self.logger.info("Length of can_dict is %s", len(can_dict))
         simple_summ = tagged_sum(can_dict[max(can_dict.keys(), key=lambda x: len(x))])
         # If the number of messages or vocabulary is too low, just look for a
@@ -81,7 +82,7 @@ class TextRankTsSummarizer(TsSummarizer):
         return summ
 
     def parify_text(self, msg_segment):
-        ptext = u'. '.join([TextRankTsSummarizer.flrg.sub(u'', msg['text']) for msg in msg_segment if 'text' in msg])
+        ptext = u'. '.join([TextRankTsSummarizer.flrg.sub(u'', get_msg_text(msg)) for msg in msg_segment])
         self.logger.debug("Parified text is %s", ptext)
         return ptext
 

--- a/utils.py
+++ b/utils.py
@@ -28,4 +28,18 @@ class ItemsCount(object):
 
 def maybe_get(cont, key, default=None):
     return cont[key] if key in cont else default
-    
+
+def get_msg_text(msg):
+    """Pull the appropriate text from the message"""
+    if 'text' in msg and len(msg['text']) > 0:
+        return msg['text']
+    if 'attachments' in msg:
+        ats = msg['attachments']
+        if len(ats) > 0:
+            at = ats[0]
+            if 'title' in at and len(at['title']) > 0:
+                return at['title']
+            if 'text' in at and len(at['text']) > 0:
+                return at['text']
+    return u"Message text not retrieved"
+            


### PR DESCRIPTION
This fixes edge cases resulting in null summaries.
- Made sure that summary text maps back to message text
- Provide default summary in cases where gensim singular value decomposition will fail
- Allow inclusion of bot text
- Filter vocabulary to prevent overload of gensim summarizer
  The hypothesis test framework is used to provide randomly generated summary sequences across several channels. The server does not depend upon the hypothesis framework so it should be possible to run and install the server without it.
