### PR TITLE
Selectable summ

### DIFF
--- a/main.py
+++ b/main.py
@@ -3,6 +3,7 @@ import requests
 import json
 import os
 from config import *
+from ts_config import SUMMS
 from slack_summary import SlackRouter
 import lsa
 import spacy.en

--- a/main.py
+++ b/main.py
@@ -4,23 +4,23 @@ import json
 import os
 from config import *
 from slack_summary import SlackRouter
-import lsa
-import spacy.en
-import spacy
+if SUMM == "spacy":
+        import lsa
+        import spacy.en
+        import spacy
 app = Flask(__name__)
 global summ
-global np 
 from utils import maybe_get
-summ = lsa.LsaSummarizer()
-# summ = None
-#nlp = spacy.en.English()
-
+summ = None
+if SUMM == "spacy":
+        summ = lsa.LsaSummarizer()
 
 @app.route("/slack", methods=['POST'])
 def slackReq():
         global summ
-        if not summ:
-                summ = lsa.LsaSummarizer()
+        if SUMM == "spacy":
+                if not summ:
+                        summ = lsa.LsaSummarizer()
 	req_data = request.form
         req = {
 	        'channel_id' : req_data.getlist('channel_id'),
@@ -36,8 +36,9 @@ def slackReq():
 @app.route("/slacktest", methods=['POST'])
 def slackTestReq():
         global summ
-        if not summ:
-                summ = lsa.LsaSummarizer()
+        if SUMM == "spacy":
+                if not summ:
+                        summ = lsa.LsaSummarizer()
 	req_data = request.form
         req = {
 	        'channel_id' : req_data.getlist('channel_id'),

--- a/main.py
+++ b/main.py
@@ -4,23 +4,22 @@ import json
 import os
 from config import *
 from slack_summary import SlackRouter
-if SUMM == "spacy":
-        import lsa
-        import spacy.en
-        import spacy
+import lsa
+import spacy.en
+import spacy
 app = Flask(__name__)
-global summ
+global lsa_summ
 from utils import maybe_get
-summ = None
-if SUMM == "spacy":
-        summ = lsa.LsaSummarizer()
+lsa_summ = None
+if "spacy" in SUMMS:
+        lsa_summ = lsa.LsaSummarizer()
 
 @app.route("/slack", methods=['POST'])
 def slackReq():
-        global summ
-        if SUMM == "spacy":
-                if not summ:
-                        summ = lsa.LsaSummarizer()
+        global lsa_summ
+        if "spacy" in SUMMS:
+                if not lsa_summ:
+                        lsa_summ = lsa.LsaSummarizer()
 	req_data = request.form
         req = {
 	        'channel_id' : req_data.getlist('channel_id'),
@@ -28,17 +27,19 @@ def slackReq():
                 'user_id' : maybe_get(req_data, 'user_id', default=''),
                 'user_name' : maybe_get(req_data, 'user_name', default=''),
                 'params' : maybe_get(req_data, 'text', default=''),
-                'summ' : summ
+                'summ' : lsa_summ
                 }
+        if "gensim" in req['params'].split():
+                req['summ'] = None
 	return (SlackRouter().get_summary(**req))
 
 
 @app.route("/slacktest", methods=['POST'])
 def slackTestReq():
-        global summ
-        if SUMM == "spacy":
-                if not summ:
-                        summ = lsa.LsaSummarizer()
+        global lsa_summ
+        if "spacy" in SUMMS:
+                if not lsa_summ:
+                        lsa_summ = lsa.LsaSummarizer()
 	req_data = request.form
         req = {
 	        'channel_id' : req_data.getlist('channel_id'),
@@ -46,11 +47,12 @@ def slackTestReq():
                 'user_id' : maybe_get(req_data, 'user_id', default=''),
                 'user_name' : maybe_get(req_data, 'user_name', default=''),
                 'params' : maybe_get(req_data, 'text', default=''),
-                'summ' : summ,
+                'summ' : lsa_summ,
                 'test' : True
                 }
+        if "gensim" in req['params'].split():
+                req['summ'] = None
 	return (SlackRouter(test=True).get_summary(**req))
-        #return u' '.join([nc, for nc in nlp(u'This is to be parsed')])
 
 def main():
         port = int(os.environ.get('PORT', 5000))

--- a/slack_summary.py
+++ b/slack_summary.py
@@ -2,7 +2,7 @@
 import requests
 import json
 from config import *
-from ts_config import DEBUG, LOG_FILE, SUMMARY_INTERVALS, TEST_JSON
+from ts_config import DEBUG, LOG_FILE, SUMMARY_INTERVALS, TEST_JSON, SUMMS
 from slacker import Slacker
 import slacker
 import logging

--- a/slack_summary.py
+++ b/slack_summary.py
@@ -9,9 +9,9 @@ import logging
 import uuid
 import re
 import io
-if SUMM == "gensim":
+if "gensim" in SUMMS:
     from ts_summarizer import TextRankTsSummarizer
-elif SUMM == "spacy":
+if "spacy" in SUMMS:
     from sp_summarizer import SpacyTsSummarizer
 
 class SlackRouter(object):
@@ -55,14 +55,13 @@ class SlackRouter(object):
             msgs = msgs[u'messages'] if u'messages' in msgs else msgs
         summ_object = args['summ']
         summ_impl = None
-        if SUMM == "gensim":
-            self.logger.info(u'Using gensim')
-            summ_impl = TextRankTsSummarizer(self.build_interval(params))
-        elif SUMM == "spacy":
+        if summ_object and "spacy" in SUMMS:
             self.logger.info(u'Using spacy')
             summ_impl = SpacyTsSummarizer(self.build_interval(params))
-        if summ_object:
             summ_impl.set_summarizer(summ_object)
+        elif "gensim" in SUMMS:
+            self.logger.info(u'Using gensim')
+            summ_impl = TextRankTsSummarizer(self.build_interval(params))
         summary = summ_impl.report_summary(msgs)
         self.logger.info(u'Summary request %s user_id: %s', request_id, user_id)
         self.logger.info(u'Summary request %s channel_name: %s', request_id, channel_name)

--- a/slack_summary.py
+++ b/slack_summary.py
@@ -1,6 +1,4 @@
 # -*- coding: utf-8 -*-
-from sp_summarizer import SpacyTsSummarizer
-#from ts_summarizer import TextRankTsSummarizer
 import requests
 import json
 from config import *
@@ -11,6 +9,10 @@ import logging
 import uuid
 import re
 import io
+if SUMM == "gensim":
+    from ts_summarizer import TextRankTsSummarizer
+elif SUMM == "spacy":
+    from sp_summarizer import SpacyTsSummarizer
 
 class SlackRouter(object):
     expr = re.compile(r'-?(\d{1,3}?)\s+(\S{1,8})\s*(.*)$')
@@ -51,12 +53,17 @@ class SlackRouter(object):
             response =  self.get_response(channel_id)
 	    msgs = (response.body)
             msgs = msgs[u'messages'] if u'messages' in msgs else msgs
-        summ = args['summ']
-        #summ_sp = TextRankTsSummarizer(self.build_interval(params))
-        summ_sp = SpacyTsSummarizer(self.build_interval(params))
-        if summ:
-            summ_sp.set_summarizer(summ)
-        summary = summ_sp.report_summary(msgs)
+        summ_object = args['summ']
+        summ_impl = None
+        if SUMM == "gensim":
+            self.logger.info(u'Using gensim')
+            summ_impl = TextRankTsSummarizer(self.build_interval(params))
+        elif SUMM == "spacy":
+            self.logger.info(u'Using spacy')
+            summ_impl = SpacyTsSummarizer(self.build_interval(params))
+        if summ_object:
+            summ_impl.set_summarizer(summ_object)
+        summary = summ_impl.report_summary(msgs)
         self.logger.info(u'Summary request %s user_id: %s', request_id, user_id)
         self.logger.info(u'Summary request %s channel_name: %s', request_id, channel_name)
         self.logger.info(u'Summary request %s parameters: %s', request_id, params)

--- a/test_hypothesis_summarizer.py
+++ b/test_hypothesis_summarizer.py
@@ -1,7 +1,6 @@
 import unittest
 import json
 import io
-#from sp_summarizer import (SpacyTsSummarizer)
 from ts_summarizer import (TextRankTsSummarizer)
 from interval_summarizer import (IntervalSpec, TsSummarizer, tagged_sum,
                                  ts_to_time)
@@ -11,7 +10,6 @@ import sys
 import config
 from ts_config import DEBUG
 from hypothesis import given
-#import hypothesis.strategies as st
 from hypothesis.strategies import (sampled_from, lists, just, integers)
 import glob
 import random
@@ -28,10 +26,6 @@ def read_dir(fdir):
     return coll
 
 test_json_msgs_c3 = [read_dir(fdir) for fdir in ['api-test',  'calypso',  'games',  'happiness',  'hg',  'jetpack',  'jetpackfuel',  'livechat',  'tickets',  'vip']]
-
-# for dirs in ['api-test',  'calypso',  'games',  'happiness',  'hg',  'jetpack',  'jetpackfuel',  'livechat',  'tickets',  'vip']:
-#     for jfile in glob.glob('./data/slack-logs-2/{}/*.json'.format(dirs)):
-#         test_json_msgs_c3 += json.load(io.open(jfile, encoding='utf-8'))
 
 print len(test_json_msgs_c3)
 

--- a/test_service_components.py
+++ b/test_service_components.py
@@ -139,6 +139,21 @@ class Test(unittest.TestCase):
         self.logger.addHandler(self.fh)
         self.logger.info("Response is %s", rv.data)
         self.assertTrue(rv.status_code == 200)
+
+    @mock.patch('slacker.Slacker')
+    def test_gensim(self, mock_slack):
+        mock_slack.return_value.channels = self.channel_mock2
+        rv = self.app.post('/slack', data=dict(
+                    channel_id='achannel',
+                    channel_name='achannel',
+                    user_id='user123456',
+                    user_name='bob2',
+                    text='2 days gensim'
+                ), follow_redirects=True)
+        self.logger.handlers = []
+        self.logger.addHandler(self.fh)
+        self.logger.info("Response is %s", rv.data)
+        self.assertTrue(rv.status_code == 200)
         
 
 if __name__ == '__main__':

--- a/test_spacy_with_hypothesis.py
+++ b/test_spacy_with_hypothesis.py
@@ -11,7 +11,6 @@ import sys
 import config
 from ts_config import DEBUG
 from hypothesis import given
-#import hypothesis.strategies as st
 from hypothesis.strategies import (sampled_from, lists, just, integers)
 import glob
 import random

--- a/test_summarizer.py
+++ b/test_summarizer.py
@@ -8,9 +8,11 @@ from datetime import datetime
 import logging
 import sys
 from ts_config import DEBUG
-from sp_summarizer import (SpacyTsSummarizer)
-import lsa
-from ts_summarizer import (TextRankTsSummarizer)
+if "spacy" in SUMMS:
+    from sp_summarizer import (SpacyTsSummarizer)
+    import lsa
+if "gensim" in SUMMS:
+    from ts_summarizer import (TextRankTsSummarizer)
 
 logger = logging.getLogger()
 logger.level = logging.DEBUG if DEBUG else logging.INFO
@@ -42,25 +44,31 @@ class TestSummarize(unittest.TestCase):
 
     def test_gensim_summarization(self):
         """Pass the intervals to summarizer"""
-        asd = [{'minutes': 60, 'size' : 2, 'txt' : u'Summary for first 60 minutes:\n'}, {'hours':12, 'size' : 1, 'txt' : u'Summary for last 12 hours:\n'}]
-        summ = None
-        summ = TextRankTsSummarizer(asd)
-        logger.debug("Testing gensim summarizer")
-        sumry = summ.summarize(TestSummarize.test_msgs)
-        logger.debug("Summary is %s", sumry)
-        self.assertTrue(len(sumry) == 2)
+        if "gensim" in SUMMS:
+            asd = [{'minutes': 60, 'size' : 2, 'txt' : u'Summary for first 60 minutes:\n'}, {'hours':12, 'size' : 1, 'txt' : u'Summary for last 12 hours:\n'}]
+            summ = None
+            summ = TextRankTsSummarizer(asd)
+            logger.debug("Testing gensim summarizer")
+            sumry = summ.summarize(TestSummarize.test_msgs)
+            logger.debug("Summary is %s", sumry)
+            self.assertTrue(len(sumry) == 2)
+        else:
+            pass
 
     def test_spacy_summarization(self):
         """Pass the intervals to summarizer"""
-        asd = [{'minutes': 60, 'size' : 2, 'txt' : u'Summary for first 60 minutes:\n'}, {'hours':12, 'size' : 1, 'txt' : u'Summary for last 12 hours:\n'}]
-        summ = None
-        lsa_summ = lsa.LsaSummarizer()
-        summ = SpacyTsSummarizer(asd)
-        summ.set_summarizer(lsa_summ)
-        logger.debug("Testing spacy summarizer")
-        sumry = summ.summarize(TestSummarize.test_msgs)
-        logger.debug("Summary is %s", sumry)
-        self.assertTrue(len(sumry) == 2)
+        if "spacy" in SUMMS:
+            asd = [{'minutes': 60, 'size' : 2, 'txt' : u'Summary for first 60 minutes:\n'}, {'hours':12, 'size' : 1, 'txt' : u'Summary for last 12 hours:\n'}]
+            summ = None
+            lsa_summ = lsa.LsaSummarizer()
+            summ = SpacyTsSummarizer(asd)
+            summ.set_summarizer(lsa_summ)
+            logger.debug("Testing spacy summarizer")
+            sumry = summ.summarize(TestSummarize.test_msgs)
+            logger.debug("Summary is %s", sumry)
+            self.assertTrue(len(sumry) == 2)
+        else:
+            pass
 
 if __name__ == '__main__':
     unittest.main()

--- a/test_summarizer.py
+++ b/test_summarizer.py
@@ -2,6 +2,7 @@ import unittest
 import json
 import io
 import config
+from config import SUMMS
 from interval_summarizer import (IntervalSpec, TsSummarizer, tagged_sum,
                                  ts_to_time)
 from datetime import datetime

--- a/test_summarizer.py
+++ b/test_summarizer.py
@@ -2,7 +2,7 @@ import unittest
 import json
 import io
 import config
-from config import SUMMS
+from ts_config import SUMMS
 from interval_summarizer import (IntervalSpec, TsSummarizer, tagged_sum,
                                  ts_to_time)
 from datetime import datetime

--- a/test_summarizer.py
+++ b/test_summarizer.py
@@ -8,11 +8,9 @@ from datetime import datetime
 import logging
 import sys
 from ts_config import DEBUG
-if config.SUMM == "spacy":
-    from sp_summarizer import (SpacyTsSummarizer)
-    import lsa
-elif config.SUMM == "gensim":
-    from ts_summarizer import (TextRankTsSummarizer)
+from sp_summarizer import (SpacyTsSummarizer)
+import lsa
+from ts_summarizer import (TextRankTsSummarizer)
 
 logger = logging.getLogger()
 logger.level = logging.DEBUG if DEBUG else logging.INFO
@@ -42,18 +40,24 @@ class TestSummarize(unittest.TestCase):
         logger.debug("First entry should be %s is %s", TestSummarize.test_msgs[4:], msgs[0][1][::-1])
         self.assertTrue(msgs[0][1][::-1] == TestSummarize.test_msgs[4:])
 
-    def test_summarization(self):
+    def test_gensim_summarization(self):
         """Pass the intervals to summarizer"""
         asd = [{'minutes': 60, 'size' : 2, 'txt' : u'Summary for first 60 minutes:\n'}, {'hours':12, 'size' : 1, 'txt' : u'Summary for last 12 hours:\n'}]
         summ = None
-        if config.SUMM == "gensim":
-            summ = TextRankTsSummarizer(asd)
-            logger.debug("Testing gensim summarizer")
-        elif config.SUMM == "spacy":
-            lsa_summ = lsa.LsaSummarizer()
-            summ = SpacyTsSummarizer(asd)
-            summ.set_summarizer(lsa_summ)
-            logger.debug("Testing spacy summarizer")
+        summ = TextRankTsSummarizer(asd)
+        logger.debug("Testing gensim summarizer")
+        sumry = summ.summarize(TestSummarize.test_msgs)
+        logger.debug("Summary is %s", sumry)
+        self.assertTrue(len(sumry) == 2)
+
+    def test_spacy_summarization(self):
+        """Pass the intervals to summarizer"""
+        asd = [{'minutes': 60, 'size' : 2, 'txt' : u'Summary for first 60 minutes:\n'}, {'hours':12, 'size' : 1, 'txt' : u'Summary for last 12 hours:\n'}]
+        summ = None
+        lsa_summ = lsa.LsaSummarizer()
+        summ = SpacyTsSummarizer(asd)
+        summ.set_summarizer(lsa_summ)
+        logger.debug("Testing spacy summarizer")
         sumry = summ.summarize(TestSummarize.test_msgs)
         logger.debug("Summary is %s", sumry)
         self.assertTrue(len(sumry) == 2)

--- a/ts_config.py
+++ b/ts_config.py
@@ -5,3 +5,4 @@ DEBUG=True
 LOG_FILE="./summary.log"
 TEST_JSON="./data/test-events-elastic.json"
 
+

--- a/ts_config.py
+++ b/ts_config.py
@@ -4,5 +4,6 @@ TS_LOG = "./ts_summ.log"
 DEBUG=True
 LOG_FILE="./summary.log"
 TEST_JSON="./data/test-events-elastic.json"
+SUMMS=["gensim", "spacy"]
 
 


### PR DESCRIPTION
Modified the summarizer to load multple summarizers at startup. Right now, both gensim and spacy summarizers are loaded at start. The administrator may modify this by editing the value of SUMMS variable in ts_config.py. The current setting is:

```
              SUMMS = ["spacy", "gensim"]
```

The user of the summarizer may specify the summarizer to user by including the name of the summarizer in the command line,

```
              /summary 10 days gensim
```

Would give a 10 day summary using the gensim summarizer.
The default summarizer is spacy
